### PR TITLE
Added new fields for order data to satisfy AN5524 requirements:

### DIFF
--- a/structures/request.go
+++ b/structures/request.go
@@ -73,6 +73,10 @@ type (
 		RecurringExpiry string `json:"recurring-expiry,omitempty"`
 		// The minimum number of days between authorizations (for variable frequency use 1)
 		RecurringFrequency string `json:"recurring-frequency,omitempty"`
+		// Must be set to true for UCOF initialization if any subsequent MIT transactions are supposed to be
+		MITsExpected bool `json:"mits-expected,omitempty"`
+		// Must be set to true for initial recurring transaction if amount will not be fixed for subsequent transactions
+		VariableAmountRecurring bool `json:"variable-amount-recurring,omitempty"`
 	}
 
 	// Address structure with detailed fields of customer(cardholder) place


### PR DESCRIPTION
 - mits-expected: must be set to true for UCOF initialization if any subsequent MIT transactions are supposed to be
 - variable-amount-recurring: must be set to true for initial recurring transaction if amount will not be fixed for subsequent transactions